### PR TITLE
[ cleanup ] version_revision-proof process

### DIFF
--- a/install.js
+++ b/install.js
@@ -21,8 +21,8 @@ async function main() {
                 break;
             case 'gambit':
                 await exec('brew install gambit-scheme');
-                await exec('ln -s /usr/local/Cellar/gambit-scheme/4.9.3_1/v4.9.3/bin/gsi /usr/local/bin/gsi');
-                await exec('ln -s /usr/local/Cellar/gambit-scheme/4.9.3_1/v4.9.3/bin/gsc /usr/local/bin/gsc');
+                await exec('CURRENTDIR=$(find /usr/local/Cellar/gambit-scheme -type l -name current)');
+                await exec('echo "::add-path::${CURRENTDIR}/bin"');
                 break;
             case 'grebil':
                 await exec('brew install gerbil-scheme');


### PR DESCRIPTION
The current install process will fail when brew decides to install
a more recent version or revision of the gambit-scheme formula.
The updated version is revision-agnostic.

I can change the `add-path` variant back to adding a bunch of symbolic
links to `/usr/local/bin` if you'd rather symlink the executables.